### PR TITLE
Add stats counter on popup

### DIFF
--- a/censei-frontend/content.js
+++ b/censei-frontend/content.js
@@ -1,3 +1,18 @@
+const getCounter = () => {
+    return localStorage.wordsCounter;
+}
+
+const incrementCounter = () => {
+    console.log("Increment Counter");
+    if (localStorage.wordsCounter) {
+        console.log('WC', localStorage.wordsCounter)
+        const newValue = parseInt(localStorage.wordsCounter) + 1;
+        localStorage.wordsCounter = newValue.toString();
+    } else {
+        localStorage.wordsCounter = "0";
+    }
+};
+
 // Get text from body
 const getBodyText = () => {
     const bodyTextList = document.querySelectorAll('h1, h2, h3, h4, h5, p, li, td, caption, span, a');
@@ -27,7 +42,7 @@ const sendToBackendAndWaitForResponse = () => {
 
             if (currentElementText !== newText) {
                 // Increment counter for wordsCensored
-                console.log("Changes Made");
+                incrementCounter();
             }
             bodyTextList[i].innerHTML = newText;
         })
@@ -40,5 +55,6 @@ const replaceBodyText = () => {
     sendToBackendAndWaitForResponse()
 
 };
+
 
 replaceBodyText();

--- a/censei-frontend/content.js
+++ b/censei-frontend/content.js
@@ -23,7 +23,13 @@ const sendToBackendAndWaitForResponse = () => {
             return response.json();
         })
         .then((json) => {
-            bodyTextList[i].innerHTML = json.censored_text;
+            const newText = json.censored_text.slice(1); // Removes whitespace from start
+
+            if (currentElementText !== newText) {
+                // Increment counter for wordsCensored
+                console.log("Changes Made");
+            }
+            bodyTextList[i].innerHTML = newText;
         })
     };
 

--- a/censei-frontend/content.js
+++ b/censei-frontend/content.js
@@ -1,7 +1,4 @@
-const getCounter = () => {
-    return localStorage.wordsCounter;
-}
-
+// Increments the number of words censored in chrome storage to display on extension popup
 const incrementCounter = () => {
     chrome.storage.sync.get(["wordsCensored"], function({wordsCensored}){
     if (wordsCensored) {

--- a/censei-frontend/content.js
+++ b/censei-frontend/content.js
@@ -3,14 +3,14 @@ const getCounter = () => {
 }
 
 const incrementCounter = () => {
-    console.log("Increment Counter");
-    if (localStorage.wordsCounter) {
-        console.log('WC', localStorage.wordsCounter)
-        const newValue = parseInt(localStorage.wordsCounter) + 1;
-        localStorage.wordsCounter = newValue.toString();
+    chrome.storage.sync.get(["wordsCensored"], function({wordsCensored}){
+    if (wordsCensored) {
+        let newValue = wordsCensored + 1;
+        chrome.storage.sync.set({"wordsCensored": newValue})
     } else {
-        localStorage.wordsCounter = "0";
+        chrome.storage.sync.set({ "wordsCensored": 1 });
     }
+    });
 };
 
 // Get text from body

--- a/censei-frontend/manifest.json
+++ b/censei-frontend/manifest.json
@@ -2,7 +2,7 @@
   "name": "Censei",
   "version": "1.0",
   "description": "Replace explicit words with emojis!",
-  "permissions": ["storage", "declarativeContent", "activeTab"],
+  "permissions": ["storage", "declarativeContent", "activeTab", "tabs", "<all_urls>"],
   "background": {
       "scripts": ["background.js"],
       "persistent": false

--- a/censei-frontend/popup.html
+++ b/censei-frontend/popup.html
@@ -2,14 +2,33 @@
 <html>
   <head>
     <style>
-      button {
-        height: 30px;
-        width: 30px;
-        outline: none;
+      .popup {
+        width: 10rem;
+        align-items: center;
+      }
+      .stats {
+        display: flex;
+      }
+      #counter {
+        padding-left: 5px;
+      }
+      img {
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
       }
     </style>
   </head>
   <body>
-    <button id="changeColor"></button>
+    <div class="popup">
+      <img align="center" src="./images/icon48.png"></img>
+      <h3 align="center">Censei</h3>
+      <div class="stats">
+        <p>Words Censored: </p>
+        <p id="counter"></p>
+        <button id="test">S</button>
+      </div>
+    </div>
+    <script type="text/javascript" src="./popup.js"></script>
   </body>
 </html>

--- a/censei-frontend/popup.html
+++ b/censei-frontend/popup.html
@@ -26,7 +26,6 @@
       <div class="stats">
         <p>Words Censored: </p>
         <p id="counter"></p>
-        <button id="test">S</button>
       </div>
     </div>
     <script type="text/javascript" src="./popup.js"></script>

--- a/censei-frontend/popup.js
+++ b/censei-frontend/popup.js
@@ -1,1 +1,18 @@
-alert("HIIII");
+let wordsCensored = localStorage.getItem('wordsCensored');
+
+const initFirstRun = () => {
+    if (!wordsCensored) {
+        localStorage.setItem('wordsCensored','0');
+        wordsCensored = localStorage.getItem('wordsCensored');
+    }
+}
+
+const updateCounterElement = () => {
+    const counterElement = document.getElementById("counter");
+    counterElement.innerText = wordsCensored
+}
+
+initFirstRun();
+updateCounterElement();
+
+

--- a/censei-frontend/popup.js
+++ b/censei-frontend/popup.js
@@ -1,18 +1,11 @@
-let wordsCensored = localStorage.getItem('wordsCensored');
+// const counterElement = document.getElementById("counter");
+// let wordsCensored = localStorage.getItem('wordsCensored');
+// alert(localStorage.wordsCounter)
+// counterElement.innerText = wordsCensored
 
-const initFirstRun = () => {
-    if (!wordsCensored) {
-        localStorage.setItem('wordsCensored','0');
-        wordsCensored = localStorage.getItem('wordsCensored');
-    }
-};
+import { getCounter } from './content';
 
-const updateCounterElement = () => {
-    const counterElement = document.getElementById("counter");
-    counterElement.innerText = wordsCensored
-};
+alert(getCounter());
 
-initFirstRun();
-updateCounterElement();
 
 

--- a/censei-frontend/popup.js
+++ b/censei-frontend/popup.js
@@ -5,12 +5,12 @@ const initFirstRun = () => {
         localStorage.setItem('wordsCensored','0');
         wordsCensored = localStorage.getItem('wordsCensored');
     }
-}
+};
 
 const updateCounterElement = () => {
     const counterElement = document.getElementById("counter");
     counterElement.innerText = wordsCensored
-}
+};
 
 initFirstRun();
 updateCounterElement();

--- a/censei-frontend/popup.js
+++ b/censei-frontend/popup.js
@@ -1,1 +1,1 @@
-let changeColor = document.getElementById('changeColor');
+alert("HIIII");

--- a/censei-frontend/popup.js
+++ b/censei-frontend/popup.js
@@ -1,11 +1,7 @@
-// const counterElement = document.getElementById("counter");
-// let wordsCensored = localStorage.getItem('wordsCensored');
-// alert(localStorage.wordsCounter)
-// counterElement.innerText = wordsCensored
+const counterElement = document.getElementById("counter");
 
-import { getCounter } from './content';
-
-alert(getCounter());
-
-
-
+chrome.storage.sync.get(["wordsCensored"], function({wordsCensored}){
+    if (wordsCensored) {
+        counterElement.innerText = wordsCensored
+    }
+})

--- a/censei-frontend/tst.html
+++ b/censei-frontend/tst.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    <h1>Testing no replace</h1>
+    <p>Testing replace stupid</p>
+</body>
+</html>


### PR DESCRIPTION
Using chrome storage, the extension now keeps track of the number of words that were censored and displays it upon clicking the extension